### PR TITLE
remove redundant link tag for "index.css"

### DIFF
--- a/src/template.js
+++ b/src/template.js
@@ -5,7 +5,6 @@ export default ({ body, title, initialState }) => {
       <head>
         <script>window.__APP_INITIAL_STATE__ = ${initialState}</script>
         <title>${title}</title>
-        <link rel="stylesheet" href="/assets/index.css" />
       </head>
       
       <body>


### PR DESCRIPTION
Removed the redundant `<link rel="stylesheet" href="/assets/index.css" />`